### PR TITLE
Fix package `repository.url` typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/HiDeoo/repository"
+    "url": "https://github.com/HiDeoo/regisseur"
   },
   "prettier": "@hideoo/prettier-config",
   "lint-staged": {


### PR DESCRIPTION
Just a typo fix for the NPM url